### PR TITLE
Fixes issus #4 and #5

### DIFF
--- a/pykylin/connection.py
+++ b/pykylin/connection.py
@@ -4,6 +4,7 @@ from .cursor import Cursor
 from .proxy import Proxy
 from .log import logger
 
+
 class Connection(object):
 
     def __init__(self, username, password, endpoint, project, **kwargs):
@@ -30,6 +31,12 @@ class Connection(object):
         params = {'project': self.project}
         tables = self.proxy.get(route, params=params)
         return [t['table_NAME'] for t in tables]
+
+    def list_schemas(self):
+        route = 'tables_and_columns'
+        params = {'project': self.project}
+        tables = self.proxy.get(route, params=params)
+        return [t['table_SCHEM'] for t in tables]
 
     def list_columns(self, table_name):
         table_NAME = str(table_name).upper()

--- a/pykylin/dialect.py
+++ b/pykylin/dialect.py
@@ -139,10 +139,11 @@ class KylinDialect(default.DefaultDialect):
 
     def create_connect_args(self, url):
         opts = url.translate_connect_args()
+        api_prefix = '/kylin/api/'
         args = {
             'username': opts['username'],
             'password': opts['password'],
-            'endpoint': 'http://%s:%s/%s' % (opts['host'], opts['port'], opts['database'])
+            'endpoint': 'http://%s:%s/%s' % (opts['host'], opts['port'], api_prefix)
         }
         args.update(url.query)
         return [], args

--- a/pykylin/proxy.py
+++ b/pykylin/proxy.py
@@ -7,6 +7,7 @@ from .encoding import decode
 from .errors import Error
 from .log import logger
 
+
 class Proxy(object):
 
     def __init__(self, base_url):
@@ -21,7 +22,7 @@ class Proxy(object):
         route = 'user/authentication'
         url = '%s/%s' % (self.base_url, route)
         self.user = user
-        self.password = user
+        self.password = password
         self.auth = HTTPBasicAuth(user, password)
         resp = requests.post(url, auth=self.auth, headers=self.headers)
 
@@ -36,7 +37,8 @@ class Proxy(object):
 
     def request(self, method, route, **kwargs):
         url = '%s/%s' % (self.base_url, route)
-        resp = requests.request(method, url, headers=self.headers, cookies=self.cookies, auth=self.auth, **kwargs)
+        resp = requests.request(
+            method, url, headers=self.headers, cookies=self.cookies, auth=self.auth, **kwargs)
 
         if resp.status_code != 200:
             exception = 'Unknown'
@@ -46,7 +48,8 @@ class Proxy(object):
             except ValueError:
                 pass
             finally:
-                raise Error('Error when requesting: "%s", exception: "%s"' % (route, exception))
+                raise Error(
+                    'Error when requesting: "%s", exception: "%s"' % (route, exception))
 
         return decode(resp.text)
 


### PR DESCRIPTION
# issue 3
The `get_table_names()` function needs the `pykylin.connection`  object to access to kylin, but the real object passed-in is `Engine`.That's the reason to cause this bug. To get the `connnection` object, I invoke `engine.contextual_connect()` and then fixed this bug.

```
connection = engine.contextual_connect()
```
# issue 5
This bug is caused by requesting kylin by using a wrong URL.Every URL must have the prefix of `kylin/api`.
But the function `dialect.create_connect_args()` may return a incorrect `endpoint` which leads to generate a bad url.And I set the `endpoint` always equals `kylin/api`, and then this bug never recurrented